### PR TITLE
Update package name to @gesslar/wrapify

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ console.log(iwrapify(text, 50, 4))
 
 ## CDN
 
-- esm.sh: `import {wrapify} from "https://esm.sh/wrapify"`
-- jsDelivr (ESM): `import wrapify from "https://cdn.jsdelivr.net/npm/wrapify/+esm"`
+- esm.sh: `import {wrapify} from "https://esm.sh/@gesslar/wrapify"`
+- jsDelivr (ESM): `import wrapify from "https://cdn.jsdelivr.net/npm/@gesslar/wrapify/+esm"`
 
 ## API
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wrapify",
+  "name": "@gesslar/wrapify",
   "version": "1.0.0",
   "description": "A text wrapping script.",
   "type": "module",


### PR DESCRIPTION
Updated package name to `@gesslar/wrapify`

This PR updates the package name from `wrapify` to `@gesslar/wrapify` in both the package.json and the README.md documentation. The CDN import examples have been updated to reflect this namespace change.