### PR TITLE
Potential fix for code scanning alert no. 8: Replacement of a substring with itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "email": "bmw@gesslar.dev",
     "url": "https://gesslar.dev"
   },
-  "version": "1.7.0",
+  "version": "1.8.0",
   "license": "Unlicense",
   "homepage": "https://github.com/gesslar/wrapify#readme",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "email": "bmw@gesslar.dev",
     "url": "https://gesslar.dev"
   },
-  "version": "1.6.0",
+  "version": "1.7.0",
   "license": "Unlicense",
   "homepage": "https://github.com/gesslar/wrapify#readme",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "major": "pnpm version major"
   },
   "devDependencies": {
-    "@gesslar/uglier": "^0.4.0",
+    "@gesslar/uglier": "^0.5.0",
     "eslint": "^9.39.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@gesslar/uglier':
-        specifier: ^0.4.0
-        version: 0.4.0(eslint@9.39.2)
+        specifier: ^0.5.0
+        version: 0.5.0(eslint@9.39.2)
       eslint:
         specifier: ^9.39.2
         version: 9.39.2
@@ -63,10 +63,6 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@gesslar/colours@0.0.1':
-    resolution: {integrity: sha512-dnRe/Rmjeva0SYrbjIt30THm3FQ6vsCNGYhMiHjagzTUHsIfmVgyKclRAhcoJem47PLvrC2D7VyzaUMl6OiBcQ==}
-    hasBin: true
-
   '@gesslar/colours@0.5.0':
     resolution: {integrity: sha512-q5i94ov7cNpFIunyhLpdq9nHt56nZ9iofaeFvZEyE2iVqwjLTt1g/65T5W9/7T2ARvYPizDzL9RwizuswJXeAA==}
     engines: {node: '>=22'}
@@ -76,8 +72,8 @@ packages:
     resolution: {integrity: sha512-WC/oFipSaGnZ6GGLYtIBwE2WBYw4NqrOuP8buttLPH1IrZaKObzKmGUwClrwJWN/mWb36Xw8wgMtLcLoONcZ5A==}
     engines: {node: '>=22'}
 
-  '@gesslar/uglier@0.4.0':
-    resolution: {integrity: sha512-CCnjQU6SYyJ5UqFwGy0gwU+s7BsoFjNos83lxvKeGwcxIjlJUTjzvmCjq2HD69EZfyFN5mN858K+y/9Mq9BBtA==}
+  '@gesslar/uglier@0.5.0':
+    resolution: {integrity: sha512-RBaFz6m8l2BIp6TerfEbxU0AtWZuzirQTMz0eQ8MCCs65qEfODC7DVYmrwxsu8XZcURCFqR1bQHOfRwf+OMMPg==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
@@ -622,8 +618,6 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@gesslar/colours@0.0.1': {}
-
   '@gesslar/colours@0.5.0': {}
 
   '@gesslar/toolkit@3.6.0':
@@ -634,9 +628,9 @@ snapshots:
       json5: 2.2.3
       yaml: 2.8.2
 
-  '@gesslar/uglier@0.4.0(eslint@9.39.2)':
+  '@gesslar/uglier@0.5.0(eslint@9.39.2)':
     dependencies:
-      '@gesslar/colours': 0.0.1
+      '@gesslar/colours': 0.5.0
       '@gesslar/toolkit': 3.6.0
       '@skarab/detect-package-manager': 1.0.0
       '@stylistic/eslint-plugin': 5.6.1(eslint@9.39.2)

--- a/src/wrapify.js
+++ b/src/wrapify.js
@@ -90,7 +90,6 @@ const iwrapParagraph = (text, maxLineLength, indent) => {
   const remainingLinesLength = maxLineLength - indent
   const words = text
     .replace(/\r\n/g, "\n")
-    .replace(/\n/g, "\n")
     .split("\n")
     .map(line => line.trim())
     .join("\n")


### PR DESCRIPTION
Potential fix for [https://github.com/gesslar/wrapify/security/code-scanning/8](https://github.com/gesslar/wrapify/security/code-scanning/8)

In general, to fix “replacement of a substring with itself” issues, either remove the redundant replacement if it serves no purpose, or correct the replacement string/pattern if it was supposed to transform the text (for example, escaping, normalizing, or collapsing characters).

For this specific case in `src/wrapify.js`, the expression:

```js
.replace(/\r\n/g, "\n")
.replace(/\n/g, "\n")
.split("\n")
```

performs two newline-related operations in a row. The second line `.replace(/\n/g, "\n")` is redundant because it leaves the string unchanged. The behavior that follows (`split("\n")`, `join("\n")`, `.replace(/\n+/g, " ")`, etc.) does not depend on this no-op step. To fix the issue without changing functionality, we should delete `.replace(/\n/g, "\n")` entirely, leaving the rest of the normalization pipeline intact.

Concretely:
- Edit `src/wrapify.js` within the `iwrapParagraph` function.
- Remove the `.replace(/\n/g, "\n")` call at line 93.
- No new imports or helper methods are required; this is a straightforward removal of dead code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
