### PR TITLE
Updating license and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ console.log(iwrapify(text, 50, 4))
 
 Both helpers normalize blank lines between paragraphs and collapse excessive
 whitespace. Empty, `null`, or `undefined` input returns an empty string.
-`@gesslar/wrapify` is licensed under the [0BSD License](LICENSE.txt).
+
 ## License
 
-`@gesslar/wrapify` is released into the public domain under the [0BSD](LICENSE.txt).
+`@gesslar/wrapify` is released under the [0BSD](LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ indents.
 ## Install
 
 ```bash
-npm install wrapify
+npm install @gesslar/wrapify
 ```
 
 ## Usage
@@ -14,7 +14,7 @@ npm install wrapify
 ### ESM (Node/Deno/Browsers)
 
 ```js
-import wrapify, {wrapify as wrap, iwrapify} from "wrapify"
+import wrapify, {wrapify as wrap, iwrapify} from "@gesslar/wrapify"
 
 const text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
 console.log(wrap(text, 50, 2))
@@ -28,8 +28,8 @@ console.log(iwrapify(text, 50, 4))
 
 ## API
 
-- `wrapify(text?, maxLineLength = 80, indent = 3)` – wraps text with a hanging
-  indent applied to every line.
+- `wrapify(text?, maxLineLength = 80, indent = 3)` – wraps text with indent
+  applied indent applied to first line.
 - `iwrapify(text?, maxLineLength = 80, indent = 4)` – wraps text with an indent
   applied after the first line.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ console.log(iwrapify(text, 50, 4))
 ## API
 
 - `wrapify(text?, maxLineLength = 80, indent = 3)` – wraps text with indent
-  applied indent applied to first line.
+  applied to first line.
 - `iwrapify(text?, maxLineLength = 80, indent = 4)` – wraps text with an indent
   applied after the first line.
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `README.md` in a set of three commits focused on license changes (commit messages: "...", "license", "license"). The head README accurately documents the `wrapify` and `iwrapify` API with correct default values (`indent = 3` and `indent = 4` respectively), and consistently references the 0BSD license in both the text and the link to `LICENSE.txt`, which matches `package.json`'s `"license": "0BSD"` field.