### PR TITLE
04 17 fixing exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/wrapify",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/wrapify",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "0BSD",
       "devDependencies": {
         "@gesslar/uglier": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "email": "bmw@gesslar.dev",
     "url": "https://gesslar.dev"
   },
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "0BSD",
   "homepage": "https://github.com/gesslar/wrapify#readme",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
     "node": ">=24"
   },
   "type": "module",
-  "main": "./wrapify.js",
-  "module": "./wrapify.js",
-  "types": "./wrapify.d.ts",
+  "main": "./src/wrapify.js",
+  "module": "./src/wrapify.js",
+  "types": "./src/wrapify.d.ts",
   "exports": {
     ".": {
-      "types": "./wrapify.d.ts",
-      "import": "./wrapify.js",
-      "default": "./wrapify.js"
+      "types": "./src/wrapify.d.ts",
+      "import": "./src/wrapify.js",
+      "default": "./src/wrapify.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
- **fixing exports**
- **2.1.1**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the package version to `2.1.1` and fixes the `exports` field in `package.json` to properly expose the module's entry points for ESM consumers and TypeScript users.

**Key changes:**
- Added a proper `exports` map with `"."` pointing to `types`, `import`, and `default` subfields, following Node.js conditional exports best practices.
- Added `"./package.json": "./package.json"` to the exports map, which is a common best practice allowing consumers to access `package.json` metadata directly.
- The `main`, `module`, and `types` top-level fields are retained for backwards compatibility with older tooling.
- `package-lock.json` updated to reflect the new version.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it's a focused, low-risk fix to the package exports configuration with no logic changes.

The changes are confined to package.json (exports map + version bump) and the auto-generated package-lock.json. The exports structure correctly follows Node.js conditional exports conventions for an ESM-only package, with types listed before import (important for TypeScript resolution order). No source code was modified. No issues found.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["2.1.1"](https://github.com/gesslar/wrapify/commit/7afc58806b445918a0e8d0132e8fa270ad08fe29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28827325)</sub>

<!-- /greptile_comment -->